### PR TITLE
Allow optional OpsManager image to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ KEY
 - key: **(required)** The contents of the client private key file for SSL client authentication.
 - keypair: **(required)** The name of an existing key pair to put on the Ops Manager instance.
 - optional_ops_manager: **(optional)** Set to 1 to deploy a second Ops Manager instance. Defaults to 0.
+- optional_ops_manager_image: **(optional)** The local file path to the raw image to boot the second Ops Manager instance. Defaults to to `""`.
 
 ## Running
 

--- a/ops-manager.tf
+++ b/ops-manager.tf
@@ -29,6 +29,18 @@ resource "openstack_compute_floatingip_associate_v2" "ops_manager_ip" {
   instance_id = "${openstack_compute_instance_v2.ops_manager.id}"
 }
 
+resource "openstack_images_image_v2" "optional_ops_manager" {
+  count           = "${var.optional_ops_manager}"
+
+  name            = "${var.project}-optional-ops-manager"
+  local_file_path = "${var.optional_ops_manager_image}"
+
+  container_format = "bare"
+  disk_format      = "raw"
+  min_disk_gb      = 80
+  min_ram_mb       = 8192
+}
+
 resource "openstack_compute_instance_v2" "optional_ops_manager" {
   count = "${var.optional_ops_manager}"
 
@@ -36,7 +48,7 @@ resource "openstack_compute_instance_v2" "optional_ops_manager" {
   region            = "${var.region}"
   availability_zone = "${var.az}"
 
-  image_id    = "${openstack_images_image_v2.ops_manager.id}"
+  image_id    = "${openstack_images_image_v2.optional_ops_manager.id}"
   flavor_name = "${var.flavor_name}"
 
   key_pair        = "${var.keypair}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,10 @@ output "optional_ops_man_floating_ip" {
   value = "${element(concat(openstack_networking_floatingip_v2.optional_ops_manager.*.address, list("")), 0)}"
 }
 
+output "optional_ops_man_private_ip" {
+  value = "${element(concat(openstack_compute_instance_v2.optional_ops_manager.*.network.0.fixed_ip_v4, list("")), 0)}"
+}
+
 output "ha_proxy_floating_ip" {
   value = "${openstack_networking_floatingip_v2.ha_proxy.address}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -82,3 +82,9 @@ variable "optional_ops_manager" {
   description = "Deploy a second Ops Manager instance."
   default     = 0
 }
+
+variable "optional_ops_manager_image" {
+  type        = "string"
+  description = "The local file path to the raw image to boot the second Ops Manager instance."
+  default     = ""
+}


### PR DESCRIPTION
The OpsManager team discovered that it was not possible to specify a different image for the optional OpsManager instance, so we have added a new optional variable for that file path.

Signed-off-by: Shaan Sapra <shsapra@pivotal.io>